### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/quarto-svelte/_schema.yml
+++ b/_extensions/quarto-svelte/_schema.yml
@@ -1,0 +1,11 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+options:
+  use:
+    type: array
+    items:
+      type: string
+    description: List of .svelte component paths to compile and inject for this document.
+    completion:
+      type: file
+      extensions: [.svelte]

--- a/_extensions/quarto-svelte/_snippets.json
+++ b/_extensions/quarto-svelte/_snippets.json
@@ -1,0 +1,20 @@
+{
+  "Svelte filter setup": {
+    "prefix": "setup",
+    "body": [
+      "filters:",
+      "  - quarto-svelte",
+      "quarto-svelte:",
+      "  use:",
+      "    - ${1:components/Widget.svelte}"
+    ],
+    "description": "Enable the filter and register Svelte component source files."
+  },
+  "Svelte component tag": {
+    "prefix": "component",
+    "body": [
+      "<${1:my-widget}></${1:my-widget}>"
+    ],
+    "description": "Insert a custom element tag for a compiled Svelte component."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/quarto-svelte/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/quarto-svelte/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html
